### PR TITLE
Fixed typos, added tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,6 @@ This example shows how to invoke sass-java from Ant using the bundled Ant task a
 
 `isindentedsyntaxsrc` (true/false)
 
-`sourcemapfile` (true/false)
+`sourcemapfile` (Path to source map file)
 
-`sourcemaproot` (true/false)
+`sourcemaproot` (Directly inserted in source maps)

--- a/src/main/java/com/cathive/sass/SassOptions.java
+++ b/src/main/java/com/cathive/sass/SassOptions.java
@@ -65,11 +65,11 @@ public class SassOptions {
         this.$options = SassLibrary.INSTANCE.sass_context_get_options(context.$context);
     }
 
-    public void setPrecission(final int precission) {
-        SassLibrary.INSTANCE.sass_option_set_precision(this.$options, precission);
+    public void setPrecision(final int precision) {
+        SassLibrary.INSTANCE.sass_option_set_precision(this.$options, precision);
     }
 
-    public int getPrecission() {
+    public int getPrecision() {
         return SassLibrary.INSTANCE.sass_option_get_precision(this.$options);
     }
 

--- a/src/main/java/com/cathive/sass/SassTask.java
+++ b/src/main/java/com/cathive/sass/SassTask.java
@@ -231,7 +231,7 @@ public class SassTask extends Task {
             options.setIncludePath(getIncludeDirs());
         }
         if (precision != null) {
-            options.setPrecission(precision);
+            options.setPrecision(precision);
         }
         if (outputStyle != null) {
             options.setOutputStyle(outputStyle);

--- a/src/test/java/com/cathive/sass/SassDataContextTest.java
+++ b/src/test/java/com/cathive/sass/SassDataContextTest.java
@@ -35,7 +35,7 @@ public class SassDataContextTest {
     @Test
     public void testCompiler() throws Exception {
         final SassDataContext context = SassDataContext.create("div { background-color: red; }");
-        context.getOptions().setPrecission(10);
+        context.getOptions().setPrecision(10);
         //context.getOptions().setSourceComments(true);
         //context.getOptions().setInputPath(Paths.get("/tmp", "simple.scss"));
         //context.getOptions().setOutputPath(Paths.get("/tmp"));

--- a/src/test/java/com/cathive/sass/SassOptionsTest.java
+++ b/src/test/java/com/cathive/sass/SassOptionsTest.java
@@ -36,10 +36,10 @@ public class SassOptionsTest {
 
 
         // Precision
-        options.setPrecission(0);
-        assertEquals(0, options.getPrecission());
-        options.setPrecission(10);
-        assertEquals(10, options.getPrecission());
+        options.setPrecision(0);
+        assertEquals(0, options.getPrecision());
+        options.setPrecision(10);
+        assertEquals(10, options.getPrecision());
 
         // Output style
         options.setOutputStyle(SassOutputStyle.NESTED);

--- a/src/test/java/com/cathive/sass/SassTaskTest.java
+++ b/src/test/java/com/cathive/sass/SassTaskTest.java
@@ -90,12 +90,7 @@ public class SassTaskTest {
 
     @Test
     public void testExecute() {
-        buildRule.executeTarget("test");
-        Path outputPath = this.workingDirectory.resolve("output");
-        Path expectedComplex = outputPath.resolve("complex.css");
-        Path expectedSimple = outputPath.resolve("simple.css");
-        Assert.assertTrue(expectedComplex.toFile().exists());
-        Assert.assertTrue(expectedSimple.toFile().exists());
+        testTask("test");
     }
 
     @Test
@@ -106,5 +101,60 @@ public class SassTaskTest {
         } catch (BuildException ex) {
             Assert.assertEquals("'in' must be set", ex.getMessage());
         }
+    }
+
+    @Test
+    public void testWithPrecision() {
+        testTask("testWithPrecision");
+    }
+
+    @Test
+    public void testWithCompressedOutputstyle() {
+        testTask("testWithCompressedOutputstyle");
+    }
+
+    @Test
+    public void testWithSourcecomments() {
+        testTask("testWithSourcecomments");
+    }
+
+    @Test
+    public void testWithSourcemapembed() {
+        testTask("testWithSourcemapembed");
+    }
+
+    @Test
+    public void testWithSourcemapcontents() {
+        testTask("testWithSourcemapcontents");
+    }
+
+    @Test
+    public void testWithomitSourcemapurl() {
+        testTask("testWithomitSourcemapurl");
+    }
+
+    @Test
+    public void testWithSourcemapfile() {
+        testTask("testWithSourcemapfile");
+    }
+
+    @Test
+    public void testWithSourcemaproot() {
+        testTask("testWithSourcemaproot");
+    }
+
+    /**
+     * A helper for basic testing of Ant targets that expect to succeed.
+     * It is expected that the Ant target performs a `clean` before running.
+     *
+     * @param targetName
+     */
+    private void testTask(final String targetName) {
+        buildRule.executeTarget(targetName);
+        Path outputPath = this.workingDirectory.resolve("output");
+        Path expectedComplex = outputPath.resolve("complex.css");
+        Path expectedSimple = outputPath.resolve("simple.css");
+        Assert.assertTrue(expectedComplex.toFile().exists());
+        Assert.assertTrue(expectedSimple.toFile().exists());
     }
 }

--- a/src/test/resources/build.xml
+++ b/src/test/resources/build.xml
@@ -38,4 +38,76 @@
             </path>
         </sass>
     </target>
+
+    <target name="testWithPrecision" depends="clean">
+        <sass outdir="${output.dir}" in="${sass-java.test.workingdir}" precision="2">
+            <path>
+                <pathelement location="${sass-java.test.workingdir}/includes1"/>
+                <pathelement location="${sass-java.test.workingdir}/includes2"/>
+            </path>
+        </sass>
+    </target>
+
+    <target name="testWithCompressedOutputstyle" depends="clean">
+        <sass outdir="${output.dir}" in="${sass-java.test.workingdir}" outputstyle="3">
+            <path>
+                <pathelement location="${sass-java.test.workingdir}/includes1"/>
+                <pathelement location="${sass-java.test.workingdir}/includes2"/>
+            </path>
+        </sass>
+    </target>
+
+    <target name="testWithSourcecomments" depends="clean">
+        <sass outdir="${output.dir}" in="${sass-java.test.workingdir}" sourcecomments="true">
+            <path>
+                <pathelement location="${sass-java.test.workingdir}/includes1"/>
+                <pathelement location="${sass-java.test.workingdir}/includes2"/>
+            </path>
+        </sass>
+    </target>
+
+    <target name="testWithSourcemapembed" depends="clean">
+        <sass outdir="${output.dir}" in="${sass-java.test.workingdir}" sourcemapembed="true">
+            <path>
+                <pathelement location="${sass-java.test.workingdir}/includes1"/>
+                <pathelement location="${sass-java.test.workingdir}/includes2"/>
+            </path>
+        </sass>
+    </target>
+
+    <target name="testWithSourcemapcontents" depends="clean">
+        <sass outdir="${output.dir}" in="${sass-java.test.workingdir}" sourcemapcontents="true">
+            <path>
+                <pathelement location="${sass-java.test.workingdir}/includes1"/>
+                <pathelement location="${sass-java.test.workingdir}/includes2"/>
+            </path>
+        </sass>
+    </target>
+
+    <target name="testWithomitSourcemapurl" depends="clean">
+        <sass outdir="${output.dir}" in="${sass-java.test.workingdir}" omitsourcemapurl="true">
+            <path>
+                <pathelement location="${sass-java.test.workingdir}/includes1"/>
+                <pathelement location="${sass-java.test.workingdir}/includes2"/>
+            </path>
+        </sass>
+    </target>
+
+    <target name="testWithSourcemapfile" depends="clean">
+        <sass outdir="${output.dir}" in="${sass-java.test.workingdir}" sourcemapfile="${sass-java.test.workingdir}/sourcemap.map">
+            <path>
+                <pathelement location="${sass-java.test.workingdir}/includes1"/>
+                <pathelement location="${sass-java.test.workingdir}/includes2"/>
+            </path>
+        </sass>
+    </target>
+	
+	<target name="testWithSourcemaproot" depends="clean">
+        <sass outdir="${output.dir}" in="${sass-java.test.workingdir}" sourcemaproot="sourcemaproot">
+            <path>
+                <pathelement location="${sass-java.test.workingdir}/includes1"/>
+                <pathelement location="${sass-java.test.workingdir}/includes2"/>
+            </path>
+        </sass>
+    </target>
 </project>


### PR DESCRIPTION
Closes #5
- Fixes a typo in the API.
- Fixes copy/paste mistake in the Ant Task section of the ReadMe
- Adds unit tests to ensure each attribute of the Ant task is covered.
